### PR TITLE
Added a set timeout before calculation of hexagon layout

### DIFF
--- a/app/js/app/directives/Hexagons.js
+++ b/app/js/app/directives/Hexagons.js
@@ -280,7 +280,7 @@ define(["app/honest/hexagon"],function(hexagon) {
                         var augmentedWildcard = JSON.parse(JSON.stringify(scope.wildCard));
 	            		augmentedQuestions.splice(scope.wildCardPosition, 0, augmentedWildcard);
 
-                        update();
+	            		setTimeout(update, 50);
 		    		} else {
 			            augmentedQuestions = null;
                         update();


### PR DESCRIPTION
I spent some time trying to come up with a sophisticated fix for this, but to no avail.

'update' calculates the layout of hexagons based on the width of the containing div, using jQuery's .Width().

Looks like there are issues with jQuery getting the widths of "100% width" elements correctly, adding a timeout lets everything render first.

A bit hacky, but it works...