### PR TITLE
Warn users if their password is less than six characters long when

### DIFF
--- a/app/partials/states/register.html
+++ b/app/partials/states/register.html
@@ -31,7 +31,7 @@
 	            <div class="large-8 medium-8 small-16 columns">
 	                <label for="account-password">
 	                    <strong>Password</strong>
-						<span class="ru-error-message" ng-if="account.password.$dirty && user.password.length < 6">
+						<span class="ru-error-message" ng-if="user.password.length < 6">
                         	Password must be at least 6 characters long
 						</span>
 	                </label>


### PR DESCRIPTION
taken to the registration page