### PR TITLE
Added new site statistics back into global navigation

### DIFF
--- a/app/partials/global_navigation.html
+++ b/app/partials/global_navigation.html
@@ -124,6 +124,7 @@
                     <li ng-show="user.role && (user.role == 'ADMIN' || user.role == 'EVENT_MANAGER')"><a ui-sref="adminEvents">Event Admin</a></li>
                     <li><a ui-sref="contentErrors">Content Errors &nbsp;<span ng-if="contentProblems !== 0" data-ot="There are {{contentProblems}} content errors!" class="dl-alert warning hide-for-small-only" aria-haspopup="true">{{contentProblems || '!'}}</span></a></li>
                     <li><a ui-sref="adminStats">Site Statistics</a></li>
+                    <li><a ui-sref="adminStatsNew">Faster Site Statistics (Beta)</a></li>
                     <!-- <li><a ui-sref="adminStatsNew">Faster Site Statistics (Beta)</a></li> -->
                 </ul>
             </li>


### PR DESCRIPTION
All the routing is already implemented here, just need to re-add this link in the global navigation for kafka site stats.