### PR TITLE
Order and sort assignments by overdue status

### DIFF
--- a/app/js/app/controllers/AssignmentsController.js
+++ b/app/js/app/controllers/AssignmentsController.js
@@ -250,10 +250,9 @@ define([], function() {
 			angular.forEach(assignments, function(assignment, index) {
 				if (assignment.gameboard.percentageCompleted < 100) {
 					var noDueDateButRecent = !assignment.dueDate && (assignment.creationDate > fourWeeksAgo);
-					assignment.overdue = assignment.dueDate && (assignment.dueDate < $scope.now);
-					var onlyJustOverdue = assignment.overdue && (assignment.dueDate >= fiveDaysAgo);
-					if (noDueDateButRecent || onlyJustOverdue) {
-						// Assignment only just overdue, or within last month but no due date.
+					var dueDateAndCurrent = assignment.dueDate && (assignment.dueDate >= fiveDaysAgo);
+					if (noDueDateButRecent || dueDateAndCurrent) {
+						// Assignment either not/only just overdue, or else set within last month but no due date.
 						$scope.myAssignments.inProgressRecent.push(assignment);
 					} else {
 						$scope.myAssignments.inProgressOld.push(assignment);

--- a/app/js/app/controllers/AssignmentsController.js
+++ b/app/js/app/controllers/AssignmentsController.js
@@ -271,10 +271,10 @@ define([], function() {
 
 		$scope.setVisibleBoard = function(state){
 			if (state === 'IN_PROGRESS_RECENT') {
-				$scope.sortPredicate = ['!overdue', '-creationDate'];
+				$scope.sortPredicate = ['!dueDate', 'dueDate', '-creationDate'];
 				$scope.assignmentsVisible = $scope.myAssignments.inProgressRecent;
 			} else if (state === 'IN_PROGRESS_OLD') {
-				$scope.sortPredicate = ['!overdue', '-creationDate'];
+				$scope.sortPredicate = ['!dueDate', 'dueDate', '-creationDate'];
 				$scope.assignmentsVisible = $scope.myAssignments.inProgressOld;
 			} else {
 				$scope.sortPredicate = '-creationDate';

--- a/app/partials/states/my_assignments.html
+++ b/app/partials/states/my_assignments.html
@@ -4,7 +4,7 @@
         <p class="hide-for-small-only">Keep track of your assignments</p>
     </div>
     <div class="medium-3 columns text-right hide-for-small-only">
-        <span data-ot="Any assignments you have been set will appear on this page." class="has-tip" aria-haspopup="true"><span class="icon-help"></span>Help</span>
+        <span data-ot="Any assignments you have been set will appear on this page.<br>Unfinished overdue assignments will show in Assignments To Do for 5 days after they are due, after which they move to Older Assignments." class="has-tip" data-html="true" aria-haspopup="true"><span class="icon-help"></span>Help</span>
     </div>
 </div>
 <div class="row assignments-wrap">
@@ -15,7 +15,7 @@
          <dd class="assignments" ng-class="assignmentsVisible == myAssignments.completed ? 'active' : ''"><a href="javascript:void(0)" ng-click="setVisibleBoard('COMPLETED')"><span class="show-for-medium-up">Completed Assignments ({{myAssignments.completed.length || 0}})</span><span class="show-for-small-only">Done ({{myAssignments.completed.length || 0}})</span></a></dd>
        </dl>
        <div class="tabs-content profile-tabs-content">
-         <div ng-repeat="assignment in assignmentsVisible | orderBy:'creationDate':true" class="assignment">
+         <div ng-repeat="assignment in assignmentsVisible | orderBy:sortPredicate" class="assignment">
             <div class="large-6 medium-7 columns">
                <div class="board-percentage">
                   <span ng-if="assignment.gameboard.percentageCompleted != 100" class="subject-physics">


### PR DESCRIPTION
On the My Assignment page, use the due date to decide which tab an assignment should be in. Recently overdue assignments from the last 5 days will remain in "To Do", as will assignments without a due date that are less than a month old.
All other incomplete assignments will go in the "Older" tab.
Overdue assignments are shown at the top of the "To Do" and "Older" tabs, but are ordered as before by date set in "Completed" tab.

I think removing the `var creationDate = new Date(assignment.creationDate);` is ok because Date objects compare correctly to integer timestamps anyway? Could someone also check I've not misspelt "assignment" because it no longer looks like a word to me . . .

---

**Pull Request Check List**
- Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- Added enough Logging to monitor expected behaviour change
- Security - XSS/Injection - All user input validated or encoded before being used in page or URL
- Security - Data Exposure - PII is not sent in URL or query params
- Security - Access Control - Suitable authorisation added to new pages
- Updated Release Procedure & Documentation