### PR TITLE
Set parameter so that Google Analytics anonamyses IP addresses

### DIFF
--- a/app/index.biology.html
+++ b/app/index.biology.html
@@ -135,7 +135,7 @@
           })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
           ga('create', 'UA-51129534-1', { 'cookieDomain': 'none' });
-
+          ga('set', 'anonymizeIp', true);
         </script>
 
         <div id="equationModal" class="reveal-modal" data-reveal>

--- a/app/index.chemistry.html
+++ b/app/index.chemistry.html
@@ -135,7 +135,7 @@
           })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
           ga('create', 'UA-51129534-1', { 'cookieDomain': 'none' });
-
+          ga('set', 'anonymizeIp', true);
         </script>
 
         <div id="equationModal" class="reveal-modal" data-reveal>

--- a/app/index.physics.html
+++ b/app/index.physics.html
@@ -135,7 +135,7 @@
           })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
           ga('create', 'UA-51129534-1', { 'cookieDomain': 'none' });
-
+          ga('set', 'anonymizeIp', true);
         </script>
 
         <div id="equationModal" class="reveal-modal" data-reveal>


### PR DESCRIPTION
Set parameter so that Google Analytics anonamyses IP addresses by zeroing out the last octet and equiv in IPv6.
Reference: https://support.google.com/analytics/answer/2763052

---

**Pull Request Check List**
- [x] Security - New dependency - Searched for any known vulnerabilities
- [ ] Peer-Reviewed