### PR TITLE
Feature/pg user streaks

### DIFF
--- a/app/js/app/app.js
+++ b/app/js/app/app.js
@@ -692,7 +692,7 @@ define([
         //var signOnTime = Number(new Date());
         $rootScope.notificationWebSocket = null;
         $rootScope.webSocketCheckTimeout = null;
-        var lastRecievedServerTime = null;
+        var lastKnownServerTime = null;
 
         $rootScope.openNotificationSocket = function() {
 
@@ -720,42 +720,30 @@ define([
 
                     var websocketMessage = JSON.parse(event.data);
 
-                    // User snapshot update:
                     if (websocketMessage.heartbeat) {
-
-                        var serverTime = websocketMessage.heartbeat;
-
-                        if (null == lastRecievedServerTime ||
-                            new Date(lastRecievedServerTime).getDate() < new Date(serverTime).getDate()) {
+                        // Update the last known server time from the message heartbeat.
+                        var newServerTime = websocketMessage.heartbeat;
+                        if (null != lastKnownServerTime && new Date(lastKnownServerTime).getDate() != new Date(newServerTime).getDate()) {
+                            // If the server time has passed midnight, streaks reset, so request a snapshot update:
                             $rootScope.notificationWebSocket.send("user-snapshot-nudge");
                         }
-                        lastRecievedServerTime = serverTime;
+                        lastKnownServerTime = newServerTime;
+                    }
 
-                    } else if (websocketMessage.userSnapshot) {
-
+                    if (websocketMessage.userSnapshot) {
                         $rootScope.user.userSnapshot = websocketMessage.userSnapshot;
                         var currentActivity = websocketMessage.userSnapshot.streakRecord ? websocketMessage.userSnapshot.streakRecord.currentActivity : 0;
                         $rootScope.streakDialToggle(currentActivity);
-                        lastRecievedServerTime = websocketMessage.userSnapshot.heartbeat;
 
                     } else if (websocketMessage.notifications) {
-
                         websocketMessage.notifications.forEach(function(entry) {
-
                             var notificationMessage = JSON.parse(entry.message);
-
                             // specific user streak update
                             if (notificationMessage.streakRecord) {
-
-                                $rootScope.user.userSnapshot.streakRecord
-                                    = notificationMessage.streakRecord;
-
+                                $rootScope.user.userSnapshot.streakRecord = notificationMessage.streakRecord;
                                 $rootScope.streakDialToggle($rootScope.user.userSnapshot.streakRecord.currentActivity);
                             }
-
                         });
-
-                        lastRecievedServerTime = websocketMessage.userSnapshot.heartbeat;
                     }
 
 
@@ -841,7 +829,13 @@ define([
         var checkForWebSocket = function() {
 
             if ($rootScope.notificationWebSocket != null) {
-                $rootScope.notificationWebSocket.send("heartbeat");
+                if (!$rootScope.user.userSnapshot) {
+                    // If we don't have a snapshot, request one.
+                    $rootScope.notificationWebSocket.send("user-snapshot-nudge");
+                } else {
+                    // Else just ping to keep connection alive.
+                    $rootScope.notificationWebSocket.send("heartbeat");
+                }
                 $rootScope.webSocketCheckTimeout = $timeout(checkForWebSocket, 60000);
             } else {
                 $rootScope.openNotificationSocket();

--- a/app/js/app/app.js
+++ b/app/js/app/app.js
@@ -692,6 +692,7 @@ define([
         //var signOnTime = Number(new Date());
         $rootScope.notificationWebSocket = null;
         $rootScope.webSocketCheckTimeout = null;
+        var lastRecievedServerTime = null;
 
         $rootScope.openNotificationSocket = function() {
 
@@ -722,18 +723,20 @@ define([
                     // User snapshot update:
                     if (websocketMessage.heartbeat) {
 
-                        var clientTime = new Date();
                         var serverTime = websocketMessage.heartbeat;
 
-                        if (clientTime.getDate() > new Date(serverTime).getDate()) {
+                        if (null == lastRecievedServerTime ||
+                            new Date(lastRecievedServerTime).getDate() < new Date(serverTime).getDate()) {
                             $rootScope.notificationWebSocket.send("user-snapshot-nudge");
                         }
+                        lastRecievedServerTime = serverTime;
 
                     } else if (websocketMessage.userSnapshot) {
 
                         $rootScope.user.userSnapshot = websocketMessage.userSnapshot;
                         var currentActivity = websocketMessage.userSnapshot.streakRecord ? websocketMessage.userSnapshot.streakRecord.currentActivity : 0;
                         $rootScope.streakDialToggle(currentActivity);
+                        lastRecievedServerTime = websocketMessage.userSnapshot.heartbeat;
 
                     } else if (websocketMessage.notifications) {
 
@@ -751,6 +754,8 @@ define([
                             }
 
                         });
+
+                        lastRecievedServerTime = websocketMessage.userSnapshot.heartbeat;
                     }
 
 

--- a/app/js/app/app.js
+++ b/app/js/app/app.js
@@ -733,10 +733,10 @@ define([
                             var notificationMessage = JSON.parse(entry.message);
 
                             // specific user streak update
-                            if (notificationMessage.streakData) {
+                            if (notificationMessage.streakRecord) {
 
                                 $rootScope.user.userSnapshot.streakRecord
-                                    = notificationMessage.streakData;
+                                    = notificationMessage.streakRecord;
 
                                 $rootScope.streakDialToggle($rootScope.user.userSnapshot.streakRecord.currentActivity);
                             }

--- a/app/js/app/app.js
+++ b/app/js/app/app.js
@@ -720,7 +720,16 @@ define([
                     var websocketMessage = JSON.parse(event.data);
 
                     // User snapshot update:
-                    if (websocketMessage.userSnapshot) {
+                    if (websocketMessage.heartbeat) {
+
+                        var clientTime = new Date();
+                        var serverTime = websocketMessage.heartbeat;
+
+                        if (clientTime.getDate() > new Date(serverTime).getDate()) {
+                            $rootScope.notificationWebSocket.send("user-snapshot-nudge");
+                        }
+
+                    } else if (websocketMessage.userSnapshot) {
 
                         $rootScope.user.userSnapshot = websocketMessage.userSnapshot;
                         var currentActivity = websocketMessage.userSnapshot.streakRecord ? websocketMessage.userSnapshot.streakRecord.currentActivity : 0;
@@ -827,8 +836,8 @@ define([
         var checkForWebSocket = function() {
 
             if ($rootScope.notificationWebSocket != null) {
-                $rootScope.notificationWebSocket.send("user-snapshot-nudge");
-                $rootScope.webSocketCheckTimeout = $timeout(checkForWebSocket, 10000);
+                $rootScope.notificationWebSocket.send("heartbeat");
+                $rootScope.webSocketCheckTimeout = $timeout(checkForWebSocket, 60000);
             } else {
                 $rootScope.openNotificationSocket();
             }


### PR DESCRIPTION
Has a couple of changes with regards to handling user snapshot requests over websockets.
We now only send heartbeats every 60 seconds, and only request an update on the user snapshot if we pass midnight server-time, so as to release pressure on the database for calculating streaks.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - XSS/Injection - All user input validated or encoded before being used in page or URL
- [ ] Security - Data Exposure - PII is not sent in URL or query params
- [ ] Security - Access Control - Suitable authorisation added to new pages
- [ ] Security - New dependency - Searched for any known vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] Updated Release Procedure & Documentation
- [x] Peer-Reviewed