### PR TITLE
Close the menu when search is opened

### DIFF
--- a/app/partials/global_navigation.html
+++ b/app/partials/global_navigation.html
@@ -17,7 +17,7 @@
            href="javascript:void(0)"
            class="ru-desktop-search-icon hide-for-small-only"
            tabindex="0"
-           ng-click="globalFlags.siteSearchOpen = true"
+           ng-click="menuClose(); globalFlags.siteSearchOpen = true"
            ng-hide="globalFlags.siteSearchOpen">
             <img src='/assets/desktop-search-icon.png' alt="Search">
         </a>


### PR DESCRIPTION
Stops having an annoying overlap when the search section is opened over the menu