### PR TITLE
Removes menu tooltips when using single sign on

### DIFF
--- a/app/js/app/directives/GlobalNavigation.js
+++ b/app/js/app/directives/GlobalNavigation.js
@@ -123,7 +123,9 @@ define(['/partials/global_navigation.html'], function(templateUrl) {
                 scope.$on("$stateChangeStart", scope.menuClose);
 
                 scope.$watch('isVisible', function(){
-                    applyDisabledToolTips();                    
+                    if (scope.isVisible) {
+                        applyDisabledToolTips();  
+                    }                
                 });
 
                 // scope.answerCountTicker = 0;


### PR DESCRIPTION
applyDasabledToolTips() would previously run on the page load, before the external provider login in Auth.js had completed. This resulted in the user not being logged in and the tooltip being set to show. This updated when the login completed but wouldn't alter the tooltip until the page reloaded. This fix holds tooltip evaluation until the menu is opened.